### PR TITLE
Add stack_action_timeout parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,7 @@ Single Heat services on the controller node:
           ha_queues: True
         max_stacks_per_tenant: 150
         max_nested_stack_depth: 10
+        stack_action_timeout: 7200
 
 Define server clients Keystone parameter:
 

--- a/heat/files/juno/heat.conf.Debian
+++ b/heat/files/juno/heat.conf.Debian
@@ -61,6 +61,12 @@ max_stacks_per_tenant = {{ server.max_stacks_per_tenant }}
 max_nested_stack_depth = {{ server.max_nested_stack_depth }}
 {%- endif %}
 
+# Timeout in seconds for stack action (ie. create or update). (integer value)
+#stack_action_timeout = 3600
+{%- if server.get('stack_action_timeout',) %}
+stack_action_timeout = {{ server.get('stack_action_timeout', 3600) }}
+{%- endif %}
+
 # Number of times to retry to bring a resource to a non-error
 # state. Set to 0 to disable retries. (integer value)
 #action_retry_limit=5

--- a/heat/files/kilo/heat.conf.Debian
+++ b/heat/files/kilo/heat.conf.Debian
@@ -201,6 +201,12 @@ max_stacks_per_tenant = {{ server.max_stacks_per_tenant }}
 max_nested_stack_depth = {{ server.max_nested_stack_depth }}
 {%- endif %}
 
+# Timeout in seconds for stack action (ie. create or update). (integer value)
+#stack_action_timeout = 3600
+{%- if server.get('stack_action_timeout',) %}
+stack_action_timeout = {{ server.get('stack_action_timeout', 3600) }}
+{%- endif %}
+
 [heat_api]
 
 #

--- a/heat/files/liberty/heat.conf.Debian
+++ b/heat/files/liberty/heat.conf.Debian
@@ -208,6 +208,12 @@ max_stacks_per_tenant = {{ server.max_stacks_per_tenant }}
 max_nested_stack_depth = {{ server.max_nested_stack_depth }}
 {%- endif %}
 
+# Timeout in seconds for stack action (ie. create or update). (integer value)
+#stack_action_timeout = 3600
+{%- if server.get('stack_action_timeout',) %}
+stack_action_timeout = {{ server.get('stack_action_timeout', 3600) }}
+{%- endif %}
+
 [heat_api]
 
 #

--- a/heat/files/mitaka/heat.conf.Debian
+++ b/heat/files/mitaka/heat.conf.Debian
@@ -216,6 +216,12 @@ max_stacks_per_tenant = {{ server.max_stacks_per_tenant }}
 max_nested_stack_depth = {{ server.max_nested_stack_depth }}
 {%- endif %}
 
+# Timeout in seconds for stack action (ie. create or update). (integer value)
+#stack_action_timeout = 3600
+{%- if server.get('stack_action_timeout',) %}
+stack_action_timeout = {{ server.get('stack_action_timeout', 3600) }}
+{%- endif %}
+
 [heat_api]
 
 #

--- a/heat/files/newton/heat.conf.Debian
+++ b/heat/files/newton/heat.conf.Debian
@@ -226,6 +226,12 @@ max_stacks_per_tenant = {{ server.max_stacks_per_tenant }}
 max_nested_stack_depth = {{ server.max_nested_stack_depth }}
 {%- endif %}
 
+# Timeout in seconds for stack action (ie. create or update). (integer value)
+#stack_action_timeout = 3600
+{%- if server.get('stack_action_timeout',) %}
+stack_action_timeout = {{ server.get('stack_action_timeout', 3600) }}
+{%- endif %}
+
 [heat_api]
 
 #

--- a/heat/files/ocata/heat.conf.Debian
+++ b/heat/files/ocata/heat.conf.Debian
@@ -92,6 +92,9 @@ max_stacks_per_tenant = {{ server.max_stacks_per_tenant }}
 
 # Timeout in seconds for stack action (ie. create or update). (integer value)
 #stack_action_timeout = 3600
+{%- if server.get('stack_action_timeout',) %}
+stack_action_timeout = {{ server.get('stack_action_timeout', 3600) }}
+{%- endif %}
 
 # The amount of time in seconds after an error has occurred that tasks may
 # continue to run before being cancelled. (integer value)

--- a/heat/files/pike/heat.conf.Debian
+++ b/heat/files/pike/heat.conf.Debian
@@ -99,6 +99,9 @@ max_stacks_per_tenant = {{ server.max_stacks_per_tenant }}
 
 # Timeout in seconds for stack action (ie. create or update). (integer value)
 #stack_action_timeout = 3600
+{%- if server.get('stack_action_timeout',) %}
+stack_action_timeout = {{ server.get('stack_action_timeout', 3600) }}
+{%- endif %}
 
 # The amount of time in seconds after an error has occurred that tasks may
 # continue to run before being cancelled. (integer value)

--- a/heat/files/queens/heat.conf.Debian
+++ b/heat/files/queens/heat.conf.Debian
@@ -90,6 +90,9 @@ max_stacks_per_tenant = {{ server.max_stacks_per_tenant }}
 
 # Timeout in seconds for stack action (ie. create or update). (integer value)
 #stack_action_timeout = 3600
+{%- if server.get('stack_action_timeout',) %}
+stack_action_timeout = {{ server.get('stack_action_timeout', 3600) }}
+{%- endif %}
 
 # The amount of time in seconds after an error has occurred that tasks may
 # continue to run before being cancelled. (integer value)

--- a/tests/pillar/server_single.sls
+++ b/tests/pillar/server_single.sls
@@ -8,6 +8,7 @@ heat:
       name: heat_domain_admin
       password: password
       domain: heat
+    stack_action_timeout: 7200
     bind:
       api_cfn:
         address: 0.0.0.0


### PR DESCRIPTION
Long running actions need more time to complete.

For example provisioning stacks with very large
volumes (houndreds of GBs), such actions can take up to a few hours.

Hi @epcim @Martin819 could anyone look into this PR, please?
Thanks!